### PR TITLE
去除 TaskNameList 关于组的 Rec 极差排序方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duty-schedule",
-  "version": "0.0.7",
+  "version": "0.0.7.1",
   "author": "qwqcode <1149527164@qq.com>",
   "description": "值日任务表 - Duty Schedule",
   "license": "GPL-2.0",

--- a/src/renderer/core/data-fate.ts
+++ b/src/renderer/core/data-fate.ts
@@ -25,7 +25,8 @@ export default class DataFate extends Vue {
 
     const sortedTaskNameList: { [areaName: string]: string[] } = {}
     _.forEach(this.$dataStore.AreaList, (area) => {
-      sortedTaskNameList[area.name] = this.$dataQuery.getTaskNameArrSorted(_.uniq(area.taskList), grpList)
+      // 任务需要人数越少越排前面，先安排
+      sortedTaskNameList[area.name] = _.sortBy(_.uniq(area.taskList), o => _.countBy(area.taskList)[o])
     })
 
     const taskSelectedCount: { [taskName: string]: number } = {}

--- a/src/renderer/core/data-query.ts
+++ b/src/renderer/core/data-query.ts
@@ -214,6 +214,9 @@ export default class DataQuery extends Vue {
     return personNamesOfAreas
   }
 
+  /**
+   * @deprecated
+   */
   public getOldTaskRecList (rangeGrpList: Grp[]) {
     const allTaskRec = _.filter(this.$dataStore.RecList, o => o.type === 'Task')
     type OldRec = {
@@ -250,6 +253,7 @@ export default class DataQuery extends Vue {
   /**
    * 获取一定规则顺序的 TaskNameArray
    *
+   * @deprecated
    * @param taskList
    * @param rangeGrpList
    * @returns 根据 rangeGrpList 的全部组中全部人的 “Task RecList 记录” 极差值生成倒序排列 ["TaskName.1", ...]


### PR DESCRIPTION
因和目前的排序方式冲突，而去除原本的 TaskNameList 关于组的 Rec 极差排序（为了消除不平均）方式

![扫描 1](https://user-images.githubusercontent.com/22412567/69900053-035cc180-13aa-11ea-9225-b23597173d05.jpeg)
![扫描](https://user-images.githubusercontent.com/22412567/69900054-03f55800-13aa-11ea-9c68-47f39710c26b.jpeg)